### PR TITLE
Create kernel SDK images

### DIFF
--- a/hack/ci/sdk.dockerfile
+++ b/hack/ci/sdk.dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:latest AS builder
+COPY . /all
+ARG KERNEL_VERSION=unknown
+ARG KERNEL_FLAVOR=zone
+RUN mkdir -p /usr/src/kernel-sdk-${KERNEL_VERSION}-${KERNEL_FLAVOR} && \
+    tar zxf -C /usr/src/kernel-sdk-${KERNEL_VERSION}-${KERNEL_FLAVOR} /all/kernel-$(uname -m)-${KERNEL_VERSION}-${KERNEL_FLAVOR}/sdk.tar.gz && \
+    mkdir -p /lib/modules/${KERNEL_VERSION} && \
+    ln -sf /usr/src/kernel-sdk-${KERNEL_VERSION}-${KERNEL_FLAVOR} /lib/modules/${KERNEL_VERSION}/build && \
+    rm -rf /all
+
+FROM scratch
+COPY --from=builder /usr/src /usr/src

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -127,3 +127,5 @@ ADDONS_SQUASHFS_PATH="${OUTPUT_DIR}/addons.squashfs"
 METADATA_PATH="${OUTPUT_DIR}/metadata"
 # shellcheck disable=SC2034
 CONFIG_GZ_PATH="${OUTPUT_DIR}/config.gz"
+# shellcheck disable=SC2034
+SDK_PATH="${OUTPUT_DIR}/sdk.tar.gz"


### PR DESCRIPTION
This adds the `ghcr.io/edera-dev/linux-kernel-sdk` OCI repository which contains the SDK data for various kernel builds produced by Edera.  Needed for third-party kernel addon images.