### PR TITLE
Add `.editorconfig` that matches current style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*.sh]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 2


### PR DESCRIPTION
This is enough to coerce my editor into following existing repo defaults for shell scripts, close if we think this if cruft/don't want.