### PR TITLE
Forgot the important part

### DIFF
--- a/hack/build/common.sh
+++ b/hack/build/common.sh
@@ -177,11 +177,12 @@ case "${KERNEL_FLAVOR}" in
 	# with the default config into $KERNEL_OBJ/.config
 	cp "${BASE_FLAVOR_CONFIG}" "${KCONFIG_FRAGMENT_DEST}"
 
-	MAKE_CONFIG_FRAGMENTS="${FLAVOR}.config"
+	MAKE_CONFIG_FRAGMENTS="${KERNEL_FLAVOR}.config"
 	;;
 esac
 
-make -C "${KERNEL_SRC}" O="${KERNEL_OBJ}" ARCH="${TARGET_ARCH_KERNEL}" "${CROSS_COMPILE_MAKE}" olddefconfig "${MAKE_CONFIG_FRAGMENTS}"
+# shellcheck disable=SC2086
+make -C "${KERNEL_SRC}" O="${KERNEL_OBJ}" ARCH="${TARGET_ARCH_KERNEL}" "${CROSS_COMPILE_MAKE}" olddefconfig $MAKE_CONFIG_FRAGMENTS
 
 # shellcheck disable=SC2034
 IMAGE_TARGET="bzImage"


### PR DESCRIPTION
Forgot the actual `common.sh` changes for https://github.com/edera-dev/linux-kernel-oci/pull/72 that actually use merging for both configs, instead of assuming the base config should be copied directly to `.config` like we did before.