### PR TITLE
Fix patch on older kernels + we don't need to build amdgpu for pre-6.1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,8 @@ architectures:
 flavors:
 - name: zone
 - name: zone-amdgpu
+  constraints:
+    lower: '6.1'
 - name: zone-openpax
   constraints:
     series:
@@ -56,7 +58,7 @@ patches:
   - series: '6.12'
     upper: '6.12.1'
 - patch: hack-around-pci-msix-restore-bugs-in-pv-domu.patch
-  lower: '5.4'
+  lower: '6.1'
   flavors:
   - zone-amdgpu
 images:


### PR DESCRIPTION
Fixes some build errors with older kernels, which we don't really need to build a variant for anyway IMO.

Should fix the CI failures on older kernels like: https://github.com/edera-dev/linux-kernel-oci/actions/runs/15448584379