### PR TITLE
WIP: Support building `nvidiagpu` kernels with fixed/specific driver versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
   packages: read
 env:
-  TEST_MATRIX_SPEC: "only-latest:flavor=zone-nvidiagpu"
+  TEST_MATRIX_SPEC: "only-latest:flavor=host,zone,zone-amdgpu,zone-nvidiagpu"
 jobs:
   test:
     name: test

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -
       rm -rf /var/lib/apt/lists/*
 ARG BUILDPLATFORM
 RUN if [ "${BUILDPLATFORM}" = "linux/amd64" ]; then \
-      apt-get update && apt-get install -y linux-headers-amd64 gcc-aarch64-linux-gnu && rm -rf /var/lib/apt/lists/*; fi
+      apt-get update && apt-get install -y linux-headers-amd64 g++-aarch64-linux-gnu gcc-aarch64-linux-gnu && rm -rf /var/lib/apt/lists/*; fi
 RUN if [ "${BUILDPLATFORM}" = "linux/arm64" ] || [ "${BUILDPLATFORM}" = "linux/aarch64" ]; then \
-      apt-get update && apt-get install -y linux-headers-arm64 gcc-x86-64-linux-gnu && rm -rf /var/lib/apt/lists/*; fi
+      apt-get update && apt-get install -y linux-headers-arm64 g++-x86-64-linux-gnu gcc-x86-64-linux-gnu && rm -rf /var/lib/apt/lists/*; fi
 RUN useradd -ms /bin/sh build
 COPY --chown=build:build . /build
 USER build

--- a/config.yaml
+++ b/config.yaml
@@ -11,9 +11,9 @@ flavors:
   constraints:
     lower: '6.1'
 - name: zone-nvidiagpu
-  # we will build variants for each of these
+  # we will generate distinct images for each of these
   # local tags. For `zone-nvidiagpu` specifically,
-  # we will build that variant with the nvidia driver
+  # we will build that distinct image with the nvidia driver
   # version defined here.
   local_tags:
   - 'nvidia-575.64.05'
@@ -22,7 +22,8 @@ flavors:
   - 'nvidia-570.172.08'
   - 'nvidia-535.261.03'
   constraints:
-    lower: '6.1'
+    series:
+    - '6.15'
 - name: zone-openpax
   constraints:
     series:

--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,16 @@ flavors:
   constraints:
     lower: '6.1'
 - name: zone-nvidiagpu
+  # we will build variants for each of these
+  # local tags. For `zone-nvidiagpu` specifically,
+  # we will build that variant with the nvidia driver
+  # version defined here.
+  local_tags:
+  - 'nvidia-575.64.05'
+  - 'nvidia-575.64.03'
+  - 'nvidia-575.64'
+  - 'nvidia-570.172.08'
+  - 'nvidia-535.261.03'
   constraints:
     lower: '6.1'
 - name: zone-openpax

--- a/hack/build/generate-docker-script.py
+++ b/hack/build/generate-docker-script.py
@@ -18,6 +18,11 @@ def is_publish_enabled() -> bool:
 def quoted(text: str) -> str:
     return '"%s"' % text
 
+def dockerify_version(version_string: str) -> str:
+    # "+" is valid for both python versions and semver,
+    # but docker rejects it for tags, so sanitize
+    return version_string.replace('+', '-')
+
 
 def docker_platforms(architectures: list[str]) -> list[str]:
     platforms = []
@@ -51,6 +56,7 @@ def docker_build(
 ) -> list[str]:
     lines = []
 
+    version = dockerify_version(version)
     root = format_image_name(
         image_name_format=CONFIG["imageNameFormat"],
         flavor=flavor,

--- a/hack/build/generate-matrix.py
+++ b/hack/build/generate-matrix.py
@@ -3,6 +3,7 @@ import sys
 
 import matrix
 from util import parse_text_constraint, maybe
+from packaging.version import Version, parse
 
 
 def construct_stable_matrix():
@@ -64,9 +65,9 @@ elif build_spec_type == "only-latest":
     first_matrix = construct_stable_matrix()
     apply_config_versions = False
     matrix.sort_matrix(first_matrix)
-    last_version = first_matrix[-1]["version"]
+    last_version = parse(first_matrix[-1]["version"]).base_version
     last_version_builds = list(
-        filter(lambda build: build["version"] == last_version, first_matrix)
+        filter(lambda build: last_version in build["version"], first_matrix)
     )
     first_matrix = last_version_builds
 elif build_spec_type == "override":

--- a/hack/build/matrix.py
+++ b/hack/build/matrix.py
@@ -274,7 +274,7 @@ def generate_matrix(tags: dict[str, str]) -> list[dict[str, any]]:
                     produces = []
                     local_version_tags = []
                     for tag in version_tags:
-                        local_append = tag+"-"+local_tag
+                        local_append = tag+"+"+local_tag
                         local_version_tags.append(local_append)
                         # local_version = version+"-"+local_tag
                         kernel_output = format_image_name(

--- a/hack/build/matrix.py
+++ b/hack/build/matrix.py
@@ -192,7 +192,7 @@ def filter_matrix(
         version = build["version"]
         version_info = parse(version)
         flavor = build["flavor"]
-        is_current_release = is_release_current(version)
+        is_current_release = is_release_current(version_info.base_version)
         should_build = matches_constraints(
             version_info, flavor, constraint, is_current_release=is_current_release
         )
@@ -207,7 +207,7 @@ def filter_config_versions(builds: list[dict[str, any]]) -> list[dict[str, any]]
         version = build["version"]
         version_info = parse(version)
         flavor = build["flavor"]
-        is_current_release = is_release_current(version)
+        is_current_release = is_release_current(version_info.base_version)
         should_build = False
         for constraint in CONFIG["versions"]:
             if matches_constraints(
@@ -274,7 +274,7 @@ def generate_matrix(tags: dict[str, str]) -> list[dict[str, any]]:
                     produces = []
                     local_version_tags = []
                     for tag in version_tags:
-                        local_append = tag+"+"+local_tag
+                        local_append = tag+"-"+local_tag
                         local_version_tags.append(local_append)
                         # local_version = version+"-"+local_tag
                         kernel_output = format_image_name(
@@ -449,7 +449,7 @@ def pick_runner(build: dict[str, any]) -> str:
     flavor: str = build["flavor"]
     for runner in CONFIG["runners"]:
         if matches_constraints(
-            version_info, flavor, runner, is_current_release=is_release_current(version)
+            version_info, flavor, runner, is_current_release=is_release_current(version_info.base_version)
         ):
             return runner["name"]
     raise Exception("No runner found for build %s" % build)

--- a/hack/build/nvidiagpu-common.sh
+++ b/hack/build/nvidiagpu-common.sh
@@ -11,7 +11,7 @@ NV_KMOD_REPO_NAME=open-gpu-kernel-modules
 rm -rf "$NV_EXTRACT_PATH"
 
 # This will also be used to later fetch the correct firmware blob from the userspace pkg
-NV_VERSION="$(echo "${KERNEL_VERSION}" | awk -F'+nvidia-' '{print $2}')"
+NV_VERSION="$(echo "${KERNEL_VERSION}" | awk -F'-nvidia-' '{print $2}')"
 
 if [ -z "$NV_VERSION" ]; then
 	echo "Could not extract nvidia driver version from ${NV_VERSION}!"

--- a/hack/build/nvidiagpu-common.sh
+++ b/hack/build/nvidiagpu-common.sh
@@ -40,11 +40,18 @@ tar -xzf "$ARCHIVE" -C "$NV_WORKDIR"
 OLDPWD=$(pwd)
 cd "$NV_WORKDIR"/"$NV_KMOD_REPO_OWNER"-*
 
-make -C . SYSSRC="${KERNEL_SRC}" SYSOUT="${KERNEL_OBJ}" TARGET_ARCH="${TARGET_ARCH_KERNEL}" -j"${KERNEL_BUILD_JOBS}" "${CROSS_COMPILE_MAKE}"  modules
+# upstream does support arm64 builds with these overrides
+if [ "${TARGET_ARCH_STANDARD}" = "aarch64" ]; then
+    CROSS_ENV="env TARGET_ARCH=aarch64 CC=aarch64-linux-gnu-gcc LD=aarch64-linux-gnu-ld AR=aarch64-linux-gnu-ar CXX=aarch64-linux-gnu-g++ OBJCOPY=aarch64-linux-gnu-objcopy"
+else
+    CROSS_ENV=""
+fi
+
+${CROSS_ENV} make -C . SYSSRC="${KERNEL_SRC}" SYSOUT="${KERNEL_OBJ}" -j"${KERNEL_BUILD_JOBS}" "${CROSS_COMPILE_MAKE}"  modules
 
 echo "Nvidia $NV_VERSION build done"
 
-make -C . SYSSRC="${KERNEL_SRC}" SYSOUT="${KERNEL_OBJ}" TARGET_ARCH="${TARGET_ARCH_KERNEL}" -j"${KERNEL_BUILD_JOBS}" "${CROSS_COMPILE_MAKE}" INSTALL_MOD_PATH="${MODULES_INSTALL_PATH}" modules_install
+${CROSS_ENV} make -C . SYSSRC="${KERNEL_SRC}" SYSOUT="${KERNEL_OBJ}" -j"${KERNEL_BUILD_JOBS}" "${CROSS_COMPILE_MAKE}" INSTALL_MOD_PATH="${MODULES_INSTALL_PATH}" modules_install
 
 echo "Nvidia $NV_VERSION install done"
 


### PR DESCRIPTION
Fixes: https://github.com/edera-dev/linux-kernel-oci/issues/101

This introduces a new field in `config.yaml` called `local_tags`.

Local tags are just "extra builds" that will be built and tagged, on top of the existing version/flavor/variant combo, if present.

So a `config.yaml` like this:

```
- name: zone-nvidiagpu
  constraints:
    series:
    - '6.15'
```

would generate the following (current behavior):

> build zone-nvidiagpu 6.15.8 for x86_64, aarch64 with tags 6, 6.15, 6.15.8, latest, stable to ghcr.io/edera-dev/zone-nvidiagpu-kernel
```

But adding `local_tags` like so would generate **2 builds** like so:

- name: zone-nvidiagpu
  # we will generate distinct images for each of these
  # local tags. For `zone-nvidiagpu` specifically,
  # we will build that distinct image with the nvidia driver
  # version defined here.
  local_tags:
  - 'nvidia-575.64.05'
  - 'nvidia-575.64.03'
  constraints:
    series:
    - '6.15'
```

Will generate the following:

> build zone-nvidiagpu 6.15.8-nvidia-575.64.05 for x86_64, aarch64 with tags 6-nvidia-575.64.05, 6.15-nvidia-575.64.05, 6.15.8-nvidia-575.64.05, latest-nvidia-575.64.05, stable-nvidia-575.64.05 to ghcr.io/edera-dev/zone-nvidiagpu-kernel
> build zone-nvidiagpu 6.15.8-nvidia-575.64.03 for x86_64, aarch64 with tags 6-nvidia-575.64.03, 6.15-nvidia-575.64.03, 6.15.8-nvidia-575.64.03, latest-nvidia-575.64.03, stable-nvidia-575.64.03 to ghcr.io/edera-dev/zone-nvidiagpu-kernel

`local_tags` is intended to be a relatively generic mechanism to generate extra tagged builds for any `flavor/variant` combo, but it has special meaning for the `zone-nvidiagpu` variant build. The above `local_tags` from the generated builds will be used to determine which kernel module release to fetch and build from https://github.com/NVIDIA/open-gpu-kernel-modules, and also which runtime package to fetch+extract GPU firmware from, for that build.

There may be permutations of builds we will want that this approach doesn't cover but this works well enough for now.

Also fixes aarch64 builds failing with `nvidiagpu`: https://github.com/edera-dev/linux-kernel-oci/actions/runs/16479200626/job/46588787440