### PR TITLE
nvidia: Force Xen-compatible DMA codepath

### DIFF
--- a/hack/build/nvidiagpu-common.sh
+++ b/hack/build/nvidiagpu-common.sh
@@ -42,6 +42,9 @@ tar -xzf "$ARCHIVE" -C "$NV_WORKDIR"
 OLDPWD=$(pwd)
 cd "$NV_WORKDIR"/"$NV_KMOD_REPO_OWNER"-*
 
+# Apply nvidia hackpatches if we have them
+for patch in "${OLDPWD}"/patches-nvidia/*.patch; do patch -p1 < "$patch"; done
+
 if [ "${TARGET_ARCH_STANDARD}" = "aarch64" ]; then
 	CROSS_ENV="env CC=aarch64-linux-gnu-gcc LD=aarch64-linux-gnu-ld AR=aarch64-linux-gnu-ar CXX=aarch64-linux-gnu-g++ OBJCOPY=aarch64-linux-gnu-objcopy"
 else

--- a/patches-nvidia/0001-Hack-Xen-detection-for-Edera.patch
+++ b/patches-nvidia/0001-Hack-Xen-detection-for-Edera.patch
@@ -1,0 +1,48 @@
+From d14d762911594a3b4c9dd11f15105e80d2e4335b Mon Sep 17 00:00:00 2001
+From: Benjamin Leggett <benjamin@edera.io>
+Date: Mon, 28 Jul 2025 20:06:45 -0400
+Subject: [PATCH] Edera hack
+
+---
+ kernel-open/nvidia/nv-pat.c | 11 ++++-------
+ 1 file changed, 4 insertions(+), 7 deletions(-)
+
+diff --git a/kernel-open/nvidia/nv-pat.c b/kernel-open/nvidia/nv-pat.c
+index 1fa530d9..83c00eab 100644
+--- a/kernel-open/nvidia/nv-pat.c
++++ b/kernel-open/nvidia/nv-pat.c
+@@ -40,12 +40,9 @@ int nv_pat_mode = NV_PAT_MODE_DISABLED;
+  * WC entry is as expected before using PAT.
+  */
+ 
+-#if defined(CONFIG_X86_PAT)
+-#define NV_ENABLE_BUILTIN_PAT_SUPPORT 0
+-#else
++// HACK(edera) - force use of builtin PAT even on x86 to work around
++// buggy PAT detection under Xen
+ #define NV_ENABLE_BUILTIN_PAT_SUPPORT 1
+-#endif
+-
+ 
+ #define NV_READ_PAT_ENTRIES(pat1, pat2)   rdmsr(0x277, (pat1), (pat2))
+ #define NV_WRITE_PAT_ENTRIES(pat1, pat2)  wrmsr(0x277, (pat1), (pat2))
+@@ -63,14 +60,14 @@ static inline void nv_disable_caches(unsigned long *cr4)
+     wbinvd();
+     *cr4 = NV_READ_CR4();
+     if (*cr4 & 0x80) NV_WRITE_CR4(*cr4 & ~0x80);
+-    __flush_tlb();
++    __flush_tlb_local();
+ }
+ 
+ static inline void nv_enable_caches(unsigned long cr4)
+ {
+     unsigned long cr0 = read_cr0();
+     wbinvd();
+-    __flush_tlb();
++    __flush_tlb_local();
+     write_cr0((cr0 & 0x9fffffff));
+     if (cr4 & 0x80) NV_WRITE_CR4(cr4);
+ }
+-- 
+2.50.1
+

--- a/patches-nvidia/0002-Force-Xen-workarounds-for-DMA.patch
+++ b/patches-nvidia/0002-Force-Xen-workarounds-for-DMA.patch
@@ -1,0 +1,51 @@
+From 8ec2c5438c18f26f24ebd12b2651ba6e13957d8b Mon Sep 17 00:00:00 2001
+From: Benjamin Leggett <benjamin@edera.io>
+Date: Tue, 29 Jul 2025 15:18:47 -0400
+Subject: [PATCH] Force Xen workarounds for DMA
+
+---
+ kernel-open/common/inc/nv-linux.h |  3 +++
+ kernel-open/conftest.sh           | 13 +++++++------
+ 2 files changed, 10 insertions(+), 6 deletions(-)
+
+diff --git a/kernel-open/common/inc/nv-linux.h b/kernel-open/common/inc/nv-linux.h
+index 0cdcabc2..a3f01512 100644
+--- a/kernel-open/common/inc/nv-linux.h
++++ b/kernel-open/common/inc/nv-linux.h
+@@ -88,6 +88,9 @@
+ #define VM_DONTDUMP    0x00000000
+ #endif
+ 
++// EDERA: Force this on for zone kernels
++#define NV_DOM0_KERNEL_PRESENT
++
+ #include <linux/init.h>             /* module_init, module_exit         */
+ #include <linux/types.h>            /* pic_t, size_t, __u32, etc        */
+ #include <linux/errno.h>            /* error codes                      */
+diff --git a/kernel-open/conftest.sh b/kernel-open/conftest.sh
+index 796e892d..2420326a 100755
+--- a/kernel-open/conftest.sh
++++ b/kernel-open/conftest.sh
+@@ -767,12 +767,13 @@ compile_test() {
+             compile_check_conftest "$CODE" "NV_IOREMAP_CACHE_SHARED_PRESENT" "" "functions"
+         ;;
+         dom0_kernel_present)
+-            # Add config parameter if running on DOM0.
+-            if [ -n "$VGX_BUILD" ]; then
+-                echo "#define NV_DOM0_KERNEL_PRESENT" | append_conftest "generic"
+-            else
+-                echo "#undef NV_DOM0_KERNEL_PRESENT" | append_conftest "generic"
+-            fi
++            # EDERA: Drop this
++            # # Add config parameter if running on DOM0.
++            # if [ -n "$VGX_BUILD" ]; then
++            #     echo "#define NV_DOM0_KERNEL_PRESENT" | append_conftest "generic"
++            # else
++            #     echo "#undef NV_DOM0_KERNEL_PRESENT" | append_conftest "generic"
++            # fi
+             return
+         ;;
+ 
+-- 
+2.50.1
+


### PR DESCRIPTION
The nvidia driver has explicit codepaths to use alt scatter/gather DMA mapping routines under Xen, to avoid SWIOTLB:

```
 * DO NOT use sg_alloc_table_from_pages on Xen Server, even if it's available.
 * This will glom multiple pages into a single sg element, which
 * xen_swiotlb_map_sg_attrs may try to route to the SWIOTLB. We must only use
 * single-page sg elements on Xen Server.
 */
```
These alt routines are only used if `NV_DOM0_KERNEL_PRESENT` is defined, but they are useful in DomU PVs as well, for the same reasons, so this patch just forcibly defines the flag for zone kernels.





(Relevant commit is 6bc114408a900c79da8638e5e47657bf91254f2e, will drop the others when https://github.com/edera-dev/linux-kernel-oci/pull/103 merges and this is rebased)