### PR TITLE
feat(build): auto build kernels weekly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build Kernels
 on:
+  # Weekly auto-build
+  schedule:
+    - cron: "0 0 * * 1"
   workflow_dispatch:
     inputs:
       spec:


### PR DESCRIPTION
It doesn't seem like we are building all our kernels on an automated schedule to pick up the latest. The last full build looks like it was 3 months ago so the `latest` and `stable` tags are out of date from what they should be. 

```
➜ crane export ghcr.io/edera-dev/zone-kernel:stable | tar -Oxf - kernel/metadata
KERNEL_ARCH=x86_64
KERNEL_VERSION=6.15.1
KERNEL_FLAVOR=zone
KERNEL_CONFIG=sha256:b483a8fb9a3bbab9f8d1ae0d84a2536e101d21561f4f0bc0c1f9f83ace8ddc01

➜ crane export ghcr.io/edera-dev/zone-kernel:latest | tar -Oxf - kernel/metadata
KERNEL_ARCH=x86_64
KERNEL_VERSION=6.15.1
KERNEL_FLAVOR=zone
KERNEL_CONFIG=sha256:b483a8fb9a3bbab9f8d1ae0d84a2536e101d21561f4f0bc0c1f9f83ace8ddc01
```