### PR TITLE
Shared build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
       with:
         egress-policy: audit
 
+    - name: Maximize build space
+      uses: ublue-os/remove-unwanted-software@6bdddc50e67c21ebe9d3316539b3a025345fdc81 # v9
+
     - name: checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,6 @@ jobs:
       with:
         egress-policy: audit
 
-    - name: Maximize build space
-      uses: ublue-os/remove-unwanted-software@6bdddc50e67c21ebe9d3316539b3a025345fdc81 # v9
-
     - name: checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Kernels
+name: Kernel Build
 on:
   # Weekly auto-build
   schedule:
@@ -15,87 +15,15 @@ on:
         type: boolean
         default: true
         required: true
+
+# this job will publish images, and needs higher perms.
 permissions:
   contents: read
   packages: write
   id-token: write
-concurrency:
-  group: "kernel-builder"
 jobs:
-  matrix:
-    name: matrix
-    runs-on: ubuntu-latest
-    steps:
-    - name: Harden the runner (Audit all outbound calls)
-      uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-      with:
-        egress-policy: audit
-
-    - name: checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      with:
-        submodules: recursive
-    - name: install dependencies
-      run: ./hack/build/install-matrix-deps.sh
-    - name: generate matrix
-      run: 'PATH="${HOME}/go/bin:${PATH}" ./hack/build/generate-matrix.sh "${{ inputs.spec }}"'
-    - name: upload matrix
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: matrix
-        path: "matrix.json"
-        compression-level: 0
-    - name: capture matrix
-      id: capture-matrix
-      run: >
-        echo "matrix=$(cat matrix.json)" >> "${GITHUB_OUTPUT}"
-    outputs:
-      matrix: "${{ steps.capture-matrix.outputs.matrix }}"
-  build:
-    name: "build ${{ matrix.builds.version }} ${{ matrix.builds.flavor }}"
-    needs: matrix
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.matrix.outputs.matrix) }}
-    runs-on: "${{ matrix.builds.runner }}"
-    env:
-      KERNEL_PUBLISH: "${{ inputs.publish }}"
-      KERNEL_VERSION: "${{ matrix.builds.version }}"
-      KERNEL_SRC_URL: "${{ matrix.builds.source }}"
-      FIRMWARE_URL: "${{ matrix.builds.firmware_url }}"
-      FIRMWARE_SIG_URL: "${{ matrix.builds.firmware_sig_url }}"
-      KERNEL_FLAVOR: "${{ matrix.builds.flavor }}"
-      KERNEL_TAGS: "${{ join(matrix.builds.tags, ',') }}"
-      KERNEL_ARCHITECTURES: "${{ join(matrix.builds.architectures, ',') }}"
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          egress-policy: audit
-
-      - name: checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          submodules: recursive
-      - name: install cosign
-        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
-      - name: docker setup linux-kernel-oci
-        run: sudo python3 ./hack/build/docker-setup.py
-      - name: docker setup buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
-      - name: docker login ghcr.io
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
-        with:
-          registry: ghcr.io
-          username: "${{github.actor}}"
-          password: "${{secrets.GITHUB_TOKEN}}"
-      - name: generate docker script
-        run: "./hack/build/generate-docker-script.sh"
-      - name: upload docker script
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: "build-${{ matrix.builds.version }}-${{ matrix.builds.flavor }}.sh"
-          path: "docker.sh"
-          compression-level: 0
-      - name: run docker script
-        run: sh -x docker.sh
+  test:
+    uses: ./.github/workflows/matrix.yml
+    with:
+      spec: inputs.spec
+      publish: inputs.publish

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -1,0 +1,94 @@
+name: Build Kernel Matrix
+on:
+  workflow_call:
+    inputs:
+      spec:
+        description: 'Build Specification'
+        type: string
+        default: "new"
+        required: true
+      publish:
+        description: 'Publish Builds'
+        type: boolean
+        default: true
+        required: true
+concurrency:
+  group: "kernel-builder"
+jobs:
+  matrix:
+    name: matrix
+    runs-on: ubuntu-latest
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+      with:
+        egress-policy: audit
+
+    - name: checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      with:
+        submodules: recursive
+    - name: install dependencies
+      run: ./hack/build/install-matrix-deps.sh
+    - name: generate matrix
+      run: 'PATH="${HOME}/go/bin:${PATH}" ./hack/build/generate-matrix.sh "${{ inputs.spec }}"'
+    - name: upload matrix
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: matrix
+        path: "matrix.json"
+        compression-level: 0
+    - name: capture matrix
+      id: capture-matrix
+      run: >
+        echo "matrix=$(cat matrix.json)" >> "${GITHUB_OUTPUT}"
+    outputs:
+      matrix: "${{ steps.capture-matrix.outputs.matrix }}"
+  build:
+    name: "build ${{ matrix.builds.version }} ${{ matrix.builds.flavor }}"
+    needs: matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix.outputs.matrix) }}
+    runs-on: "${{ matrix.builds.runner }}"
+    env:
+      KERNEL_PUBLISH: "${{ inputs.publish }}"
+      KERNEL_VERSION: "${{ matrix.builds.version }}"
+      KERNEL_SRC_URL: "${{ matrix.builds.source }}"
+      FIRMWARE_URL: "${{ matrix.builds.firmware_url }}"
+      FIRMWARE_SIG_URL: "${{ matrix.builds.firmware_sig_url }}"
+      KERNEL_FLAVOR: "${{ matrix.builds.flavor }}"
+      KERNEL_TAGS: "${{ join(matrix.builds.tags, ',') }}"
+      KERNEL_ARCHITECTURES: "${{ join(matrix.builds.architectures, ',') }}"
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+
+      - name: checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          submodules: recursive
+      - name: install cosign
+        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+      - name: docker setup linux-kernel-oci
+        run: sudo python3 ./hack/build/docker-setup.py
+      - name: docker setup buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
+      - name: docker login ghcr.io
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: ghcr.io
+          username: "${{github.actor}}"
+          password: "${{secrets.GITHUB_TOKEN}}"
+      - name: generate docker script
+        run: "./hack/build/generate-docker-script.sh"
+      - name: upload docker script
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: "build-${{ matrix.builds.version }}-${{ matrix.builds.flavor }}.sh"
+          path: "docker.sh"
+          compression-level: 0
+      - name: run docker script
+        run: sh -x docker.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,6 @@ jobs:
       with:
         egress-policy: audit
 
-    - name: Maximize build space
-      uses: ublue-os/remove-unwanted-software@6bdddc50e67c21ebe9d3316539b3a025345fdc81 # v9
-
     - name: checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ jobs:
       with:
         egress-policy: audit
 
+    - name: Maximize build space
+      uses: ublue-os/remove-unwanted-software@6bdddc50e67c21ebe9d3316539b3a025345fdc81 # v9
+
     - name: checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,69 +7,9 @@ on:
 permissions:
   contents: read
   packages: read
-env:
-  TEST_MATRIX_SPEC: "only-latest:flavor=host,zone,zone-nvidiagpu"
 jobs:
   test:
-    name: test
-    runs-on: edera-large
-    env:
-      FIRMWARE_URL: "https://cdn.kernel.org/pub/linux/kernel/firmware/linux-firmware-20250410.tar.xz"
-      FIRMWARE_SIG_URL: "https://cdn.kernel.org/pub/linux/kernel/firmware/linux-firmware-20250410.tar.sign"
-      KERNEL_ARCHITECTURES: "x86_64"
-    steps:
-    - name: Harden the runner (Audit all outbound calls)
-      uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-      with:
-        egress-policy: audit
-
-    - name: checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      with:
-        submodules: recursive
-    - name: install dependencies
-      run: ./hack/build/install-matrix-deps.sh
-    - name: generate spec-new matrix
-      run: 'PATH="${HOME}/go/bin:${PATH}" KERNEL_BUILD_SPEC="new" ./hack/build/generate-matrix.sh'
-    - name: upload spec-new matrix
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: spec-new-matrix
-        path: "matrix.json"
-        compression-level: 0
-    - name: generate spec-rebuild matrix
-      run: 'PATH="${HOME}/go/bin:${PATH}" KERNEL_BUILD_SPEC="rebuild" ./hack/build/generate-matrix.sh'
-    - name: upload spec-rebuild matrix
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: spec-rebuild-matrix
-        path: "matrix.json"
-        compression-level: 0
-    - name: generate test matrix
-      run: 'PATH="${HOME}/go/bin:${PATH}" ./hack/build/generate-matrix.sh "${TEST_MATRIX_SPEC}"'
-    - name: upload test matrix
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: test-matrix
-        path: "matrix.json"
-        compression-level: 0
-    - name: docker setup linux-kernel-oci
-      run: sudo python3 ./hack/build/docker-setup.py
-    - name: docker setup buildx
-      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
-    - name: docker login ghcr.io
-      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
-      with:
-        registry: ghcr.io
-        username: "${{github.actor}}"
-        password: "${{secrets.GITHUB_TOKEN}}"
-    - name: generate docker script
-      run: "./hack/build/generate-docker-script.sh matrix.json"
-    - name: upload docker script
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: "docker.sh"
-        path: "docker.sh"
-        compression-level: 0
-    - name: run docker script
-      run: sh -x docker.sh
+    uses: ./.github/workflows/matrix.yml
+    with:
+      spec: "only-latest:flavor=host,zone,zone-nvidiagpu"
+      publish: false

--- a/config.yaml
+++ b/config.yaml
@@ -20,8 +20,7 @@ flavors:
   - 'nvidia-575.64.03'
   - 'nvidia-575.57.08'
   constraints:
-    series:
-    - '6.15'
+    lower: '6.15'
 - name: zone-openpax
   constraints:
     series:

--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,6 @@ flavors:
   local_tags:
   - 'nvidia-575.64.05'
   - 'nvidia-575.64.03'
-  - 'nvidia-575.57.08'
   constraints:
     lower: '6.15'
 - name: zone-openpax


### PR DESCRIPTION
Before we duplicated (sorta) logic between the CI action and the "build" action.

One of the side effects of this was we ignored the defined `config.yaml` runner size for a particular matrix combo for CI.

This moves the "matrix" bit into a shared workflow, which can either be invoked by `test.yaml` or `build.yaml`.

The permissions (including publish permissions) of the shared workflow entirely come from the declared permissions parent invoking workflow, so this doesn't alter the security model, and should build exactly the same variants as the old standalone `test` job did.

This depends on/should go in after: https://github.com/edera-dev/linux-kernel-oci/pull/113