### PR TITLE
Interpolate inputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,5 +25,5 @@ jobs:
   test:
     uses: ./.github/workflows/matrix.yml
     with:
-      spec: inputs.spec
-      publish: inputs.publish
+      spec: ${{ inputs.spec }}
+      publish: ${{ inputs.publish }}


### PR DESCRIPTION
The `build` job was failing because I wasn't interpolating the passthrough args.