### PR TITLE
fix(zone): avoid printing AMD CPU reset reasons

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -73,6 +73,8 @@ patches:
   lower: '6.1'
   flavors:
   - zone-amdgpu
+- patch: 0001-x86-CPU-AMD-avoid-printing-reset-reasons-on-Xen-domU.patch
+  lower: '6.16'
 images:
 - target: kernelsrc
   name: kernel-src

--- a/patches/0001-x86-CPU-AMD-avoid-printing-reset-reasons-on-Xen-domU.patch
+++ b/patches/0001-x86-CPU-AMD-avoid-printing-reset-reasons-on-Xen-domU.patch
@@ -1,0 +1,43 @@
+From a0774aaf7f936980c06470233e1330b6d8fc9bca Mon Sep 17 00:00:00 2001
+From: Ariadne Conill <ariadne@ariadne.space>
+Date: Thu, 4 Sep 2025 12:32:45 -0700
+Subject: [PATCH] x86/CPU/AMD: avoid printing reset reasons on Xen domU
+
+Xen domU cannot access the given MMIO address for security reasons,
+resulting in a failed hypercall in ioremap() due to permissions.
+
+Fixes: ab8131028710 ("x86/CPU/AMD: Print the reason for the last reset")
+Signed-off-by: Ariadne Conill <ariadne@ariadne.space>
+Cc: stable@vger.kernel.org
+Signed-off-by: Ariadne Conill <ariadne@ariadne.space>
+---
+ arch/x86/kernel/cpu/amd.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/arch/x86/kernel/cpu/amd.c b/arch/x86/kernel/cpu/amd.c
+index a6f88ca1a6b4..99308fba4d7d 100644
+--- a/arch/x86/kernel/cpu/amd.c
++++ b/arch/x86/kernel/cpu/amd.c
+@@ -29,6 +29,8 @@
+ # include <asm/mmconfig.h>
+ #endif
+ 
++#include <xen/xen.h>
++
+ #include "cpu.h"
+ 
+ u16 invlpgb_count_max __ro_after_init = 1;
+@@ -1333,6 +1335,10 @@ static __init int print_s5_reset_status_mmio(void)
+ 	if (!cpu_feature_enabled(X86_FEATURE_ZEN))
+ 		return 0;
+ 
++	/* Xen PV domU cannot access hardware directly, so bail for domU case */
++	if (cpu_feature_enabled(X86_FEATURE_XENPV) && !xen_initial_domain())
++		return 0;
++
+ 	addr = ioremap(FCH_PM_BASE + FCH_PM_S5_RESET_STATUS, sizeof(value));
+ 	if (!addr)
+ 		return 0;
+-- 
+2.51.0
+


### PR DESCRIPTION
The hypervisor restricts access to physical MMIO pages to domU guests, so only print CPU reset reasons in the host environment.