### PR TITLE
Bump to newer nvidia drivers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -15,8 +15,8 @@ flavors:
   # we will build that distinct image with the nvidia driver
   # version defined here.
   local_tags:
-  - 'nvidia-575.64.05'
-  - 'nvidia-575.64.03'
+  - 'nvidia-580.82.09'
+  - 'nvidia-580.95.05'
   constraints:
     lower: '6.15'
 - name: zone-openpax

--- a/patches-nvidia/0001-Use-built-in-PAT-even-on-x86.patch
+++ b/patches-nvidia/0001-Use-built-in-PAT-even-on-x86.patch
@@ -1,14 +1,14 @@
-From 3b6052e852abc1384020eff979d4ee886defee91 Mon Sep 17 00:00:00 2001
+From 55d0e1e5a1e647321c13b3d346efbc7556def75c Mon Sep 17 00:00:00 2001
 From: Benjamin Leggett <benjamin@edera.io>
-Date: Thu, 31 Jul 2025 19:36:18 -0400
-Subject: [PATCH] PAT detection workaround
+Date: Fri, 3 Oct 2025 23:06:24 -0400
+Subject: [PATCH] Use built-in PAT even on x86
 
 ---
  kernel-open/nvidia/nv-pat.c | 19 ++++++++++---------
  1 file changed, 10 insertions(+), 9 deletions(-)
 
 diff --git a/kernel-open/nvidia/nv-pat.c b/kernel-open/nvidia/nv-pat.c
-index 1fa530d9..2dc5cee7 100644
+index 870dedbd..5a43bf21 100644
 --- a/kernel-open/nvidia/nv-pat.c
 +++ b/kernel-open/nvidia/nv-pat.c
 @@ -40,12 +40,9 @@ int nv_pat_mode = NV_PAT_MODE_DISABLED;
@@ -28,8 +28,8 @@ index 1fa530d9..2dc5cee7 100644
  #define NV_WRITE_PAT_ENTRIES(pat1, pat2)  wrmsr(0x277, (pat1), (pat2))
 @@ -63,14 +60,14 @@ static inline void nv_disable_caches(unsigned long *cr4)
      wbinvd();
-     *cr4 = NV_READ_CR4();
-     if (*cr4 & 0x80) NV_WRITE_CR4(*cr4 & ~0x80);
+     *cr4 = __read_cr4();
+     if (*cr4 & 0x80) __write_cr4(*cr4 & ~0x80);
 -    __flush_tlb();
 +    __flush_tlb_local();
  }
@@ -41,9 +41,9 @@ index 1fa530d9..2dc5cee7 100644
 -    __flush_tlb();
 +    __flush_tlb_local();
      write_cr0((cr0 & 0x9fffffff));
-     if (cr4 & 0x80) NV_WRITE_CR4(cr4);
+     if (cr4 & 0x80) __write_cr4(cr4);
  }
-@@ -390,8 +387,12 @@ static int nv_determine_pat_mode(void)
+@@ -317,8 +314,12 @@ static int nv_determine_pat_mode(void)
      else if (PAT_WC_index != 0xf)
      {
          nv_printf(NV_DBG_ERRORS,
@@ -59,5 +59,5 @@ index 1fa530d9..2dc5cee7 100644
      else
      {
 -- 
-2.50.1
+2.51.0
 


### PR DESCRIPTION
the 575 releases are multiple versions behind now, and no longer build with latest kernels (breaking CI).

Bump to the two most recent driver releases at time-of-PR (same as before).