### PR TITLE
Xen doublefree patch can be dropped from 6.12 as well

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -79,7 +79,7 @@ patches:
   lower: '6.16'
 - patch: 0001-9p-xen-mark-9p-transport-device-as-closing-when-remo.patch
   lower: '6.1'
-  upper: '6.18.15'
+  upper: '6.12.74'
 - patch: 0002-x86-amd_node-fix-integer-divide-by-zero-during-init.patch
   lower: '6.17'
 - patch: 0003-x86-amd_node-fix-null-pointer-dereference-if-amd_smn.patch


### PR DESCRIPTION
as the [upstream fix was backported to the 6.12 LTS tree
](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/net/9p/trans_xen.c?h=v6.12.77&id=a5d00dff97118a32fcf5fec7a4c3f864c4620c4e)

See https://github.com/edera-dev/linux-kernel-oci/pull/147#issuecomment-3999890229

Fixes e.g. https://github.com/edera-dev/linux-kernel-oci/actions/runs/22961587033/job/66653542170#step:12:1349