### PR TITLE
Fix default inputs for scheduled builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,5 +25,5 @@ jobs:
   build:
     uses: ./.github/workflows/matrix.yml
     with:
-      spec: ${{ inputs.spec }}
-      publish: ${{ inputs.publish }}
+      spec: ${{ inputs.spec || 'lts' }}
+      publish: ${{ inputs.publish == '' || inputs.publish }}


### PR DESCRIPTION
Default to 

`spec=lts` and `publish=true` for autotriggered weekly builds.