### PR TITLE
firmware: add nvidia_uvm to nvidia setup/hotplug hooks

### DIFF
--- a/hack/build/firmware.sh
+++ b/hack/build/firmware.sh
@@ -258,13 +258,13 @@ if [ "${KERNEL_FLAVOR}" = "zone-nvidiagpu" ] && [ "${TARGET_ARCH_STANDARD}" = "x
 	cat > "$ADDONS_OUTPUT_PATH/hooks/nvidia-persist.toml" <<-EOF
 [[hooks.setup]]
 overlay = "nvidia-bootstrap"
-modules = ["nvidia", "nvidia_drm"]
+modules = ["nvidia", "nvidia_drm", "nvidia_uvm"]
 execute = ["/usr/bin/nvidia-smi", "-pm", "1"]
 ignore-failure = true
 
 [[hooks.hotplug]]
 overlay = "nvidia-bootstrap"
-modules = ["nvidia", "nvidia_drm"]
+modules = ["nvidia", "nvidia_drm", "nvidia_uvm"]
 execute = ["/usr/bin/nvidia-smi", "-pm", "1"]
 ignore-failure = true
 EOF


### PR DESCRIPTION
Without this, the user would need to launch with --privileged to get the driver to load.