### PR TITLE
fix(ci): auto-rebuild and republish kernels on `main` merge if kconfigs were touched

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,15 @@ on:
   # Weekly auto-build
   schedule:
     - cron: "0 0 * * 1"
+  # A merge that changes a kernel config snippet changes the built kernel
+  # without bumping any version, so republish the release set now rather than
+  # waiting for the weekly cron. On main the tags carry no branch suffix, so
+  # this overwrites the canonical release tags with the new config content.
+  push:
+    branches:
+      - main
+    paths:
+      - "configs/**"
   workflow_dispatch:
     inputs:
       spec:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
     - main
+    # Config-snippet merges are built and published by build.yml; skip the
+    # throwaway publish:false rebuild here so a config merge builds once.
+    paths-ignore:
+    - "configs/**"
 permissions:
   contents: read
   packages: read


### PR DESCRIPTION
Avoids needing to manually trigger builds if you don't want to wait for the cronbuild, and you merged a kconfig change to `main`.

This is how I _thought_ it already worked, but I misremembered.