### PR TITLE
feat(apparmor): update kernel builder with apparmor tooling

### DIFF
--- a/Dockerfile.buildenv
+++ b/Dockerfile.buildenv
@@ -12,7 +12,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -
       build-essential squashfs-tools python3-yaml \
       patch diffutils sed mawk findutils zstd \
       python3 python3-packaging curl rsync cpio gpg grep \
-      flex bison pahole libssl-dev libelf-dev bc kmod && \
+      flex bison pahole libssl-dev libelf-dev bc kmod \
+      apparmor && \
       rm -rf /var/lib/apt/lists/*
 ARG TARGETARCH
 RUN if [ "${TARGETARCH}" = "amd64" ]; then \


### PR DESCRIPTION
Forgot this has to be done first/separately from changes that consume it, so the kernel buildenv image is available for CI.