### PR TITLE
fix(ci): also build only-latest-lts for scheduled builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,5 +35,8 @@ jobs:
     uses: ./.github/workflows/matrix.yml
     secrets: inherit
     with:
-      spec: ${{ inputs.spec || 'lts' }}
+      # schedule/push carry no inputs, so this fallback is what the cron and
+      # the configs/** push actually build. Keep it equal to the
+      # workflow_dispatch default above.
+      spec: ${{ inputs.spec || 'only-latest-lts' }}
       publish: ${{ inputs.publish == '' || inputs.publish }}


### PR DESCRIPTION
As of https://github.com/edera-dev/linux-kernel-oci/pull/186 we moved to only building/targeting/supporting "latest LTS", but that PR missed changing the default for _scheduled_ builds+publishes (only manual/CI builds+publishes).

This PR turns on `only-latest-lts` for the scheduled build+pubilsh job too, so we don't [build older LTSes during cronbuilds and confuse people](https://github.com/edera-dev/linux-kernel-oci/actions/runs/30228430069) - we weren't *using* those builds anyway, they were just noise.