### PR TITLE
fix(ci): use edera's forked ccache with .incbin fix

### DIFF
--- a/Dockerfile.buildenv
+++ b/Dockerfile.buildenv
@@ -6,6 +6,7 @@
 # update silently turns a build into a 100% cache miss. The image is rebuilt on
 # a schedule (see .github/workflows/buildenv.yml); the kernel Dockerfile pins
 # it by digest and dependabot proposes bumps as reviewable PRs.
+
 FROM debian:bookworm@sha256:9344f8b8992482f80cba753f323adeaf17690076c095ccff6cc9536be98185dc
 
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y \
@@ -21,9 +22,15 @@ RUN if [ "${TARGETARCH}" = "amd64" ]; then \
 RUN if [ "${TARGETARCH}" = "arm64" ]; then \
       apt-get update && apt-get install -y linux-headers-arm64 g++-x86-64-linux-gnu gcc-x86-64-linux-gnu && rm -rf /var/lib/apt/lists/*; fi
 
-ARG SCCACHE_VERSION=0.16.0
-ARG SCCACHE_SHA256_AMD64=aec995a83ad3dff3d14b6314e08858b7b73d35ca85a5bcf3d3a9ec07dee35588
-ARG SCCACHE_SHA256_ARM64=f73a5c39f96bb6ebb89cc7915cf182260d4cbf30765322c5e793d0fe8bd80784
+# Use the edera fork, specifically because upstream serves a stale cached object
+# for any translation unit using the assembler's `.incbin` or `.include`, because
+# the file those name is read by the assembler and so never appears in the
+# preprocessor output sccache hashes. That silently gave us kernels whose modules
+# were signed with a key absent from their own builtin keyring, which is (pardon
+# my french) a fucking nasty bug.
+ARG SCCACHE_VERSION=0.16.0-edera3
+ARG SCCACHE_SHA256_AMD64=06b5d11b457d0bc138736b29bee249ed048b1babd3d8fc8406231749a883a522
+ARG SCCACHE_SHA256_ARM64=b39e2e72082dfb9ea93694ee5b4cea9ccc57a74cae5147afed130eb966108c94
 # The wrappers must reference the real compiler by absolute path: /usr/lib/sccache
 # is first in PATH, so a bare compiler name would resolve back to the wrapper
 # itself and recurse.
@@ -33,7 +40,7 @@ RUN case "${TARGETARCH}" in \
       *) echo "unsupported TARGETARCH ${TARGETARCH}" >&2; exit 1 ;; \
     esac && \
     SCCACHE_DIST="sccache-v${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl" && \
-    curl -Lf -o /tmp/sccache.tar.gz "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_DIST}.tar.gz" && \
+    curl -Lf -o /tmp/sccache.tar.gz "https://github.com/edera-dev/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_DIST}.tar.gz" && \
     echo "${SCCACHE_SHA256}  /tmp/sccache.tar.gz" | sha256sum -c - && \
     tar -xz -C /tmp -f /tmp/sccache.tar.gz && \
     install -m 0755 "/tmp/${SCCACHE_DIST}/sccache" /usr/local/bin/sccache && \


### PR DESCRIPTION
Switches the build here to use Edera's existing forked `sccache`, specifically to pull in 

https://github.com/edera-dev/sccache/pull/1

and fix a really nasty bug that caused us to emit kernels and kmods with mismatched signatures, because the build caching would randomly return an old/invalid signing key.