### PR TITLE
fix(ci): manually bump SHA and add digestabot for OCI bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,14 +11,3 @@ updates:
     actions-dev-updates:
       dependency-type: "development"
       applies-to: "version-updates"
-- package-ecosystem: "docker"
-  directory: "/"
-  schedule:
-    interval: "daily"
-  groups:
-    image-updates:
-      dependency-type: "production"
-      applies-to: "version-updates"
-    image-dev-updates:
-      dependency-type: "development"
-      applies-to: "version-updates"

--- a/.github/workflows/digestabot.yml
+++ b/.github/workflows/digestabot.yml
@@ -1,0 +1,49 @@
+name: Image digest update
+
+# Dependabot's docker updater compares tags, so it will not reliably move a
+# digest pinned against a floating tag like kernel-buildenv:latest. digestabot
+# rewrites `tag@sha256:` pins to whatever the tag currently resolves to, which is
+# exactly what those pins need; docker is deliberately absent from
+# .github/dependabot.yml so the two do not fight over the same lines.
+on:
+  workflow_dispatch:
+  schedule:
+    # At the end of every day
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  image-update:
+    name: Image digest update
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # to push the updates
+      pull-requests: write # to open Pull requests
+      id-token: write # used to sign the commits using gitsign
+
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+      with:
+        persist-credentials: false
+
+    - uses: chainguard-dev/digestabot@33d0b78e580aa0c83fe188eb3dfad6611b662479 # v1.3.2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        signoff: true
+        author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+        committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+        labels-for-pr: automated pr, kind/cleanup
+        branch-for-pr: update-digests-${{ github.ref_name }}
+        title-for-pr: 'build(deps): update images digests (${{ github.ref_name }})'
+        description-for-pr: Update images digests
+        commit-message: 'build(deps): update images digests'
+        use-gitsign: false
+        include-files: 'Dockerfile*'

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ADD ${NV_MODULES_TARBALL_URL} /nvidia-modules.tar.gz
 # reviewed digest bumps - see Dockerfile.buildenv and buildenv.yml. Dependabot
 # keeps the pin current, with buildenv-diff.yml summarizing the package
 # changes in each bump PR.
-FROM --platform=$BUILDPLATFORM ghcr.io/edera-dev/kernel-buildenv:latest@sha256:00c0e67a93f8d3e6a1d71b03548c4b1157554e28ff117f2d12a8929335aad938 AS buildenv
+FROM --platform=$BUILDPLATFORM ghcr.io/edera-dev/kernel-buildenv:latest@sha256:0eef45e163f7d79e86dffd418dbc6874d7b967c9539f4bc7579b5d45402fffed AS buildenv
 COPY --chown=build:build . /build
 USER build
 WORKDIR /build


### PR DESCRIPTION
Github's Dependabot is pretty good for actions but seems to struggle with OCI ref updates if the image is multiarch.

So 

- Manually bump the buildimage to pull in https://github.com/edera-dev/linux-kernel-oci/pull/234
- Add a `digestabot` job for OCI bumps, like we use elsewhere, which is pretty reliable.
- Turn off docker image checks in `dependabot`