### PR TITLE
fix(host/zone): patch virtgpu to support pv scanout

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -130,6 +130,12 @@ patches:
   series: '6.18'
 - patch: 0001-feat-xen-deflate-balloon-via-oom-notifier.patch
   lower: '6.18'
+# virtio-gpu decides between DMA and guest-physical addresses on its own,
+# without the xen_domain() case vring_use_dma_api() has, so a Xen PV domain
+# hands the host addresses that resolve to somebody else's memory and the
+# display scans out garbage. This adds the xen_domain() check to fix that.
+- patch: 0001-drm-virtio-use-the-DMA-API-for-resource-backing-on-X.patch
+  series: '6.18'
 images:
 - target: kernelsrc
   name: kernel-src

--- a/patches/0001-drm-virtio-use-the-DMA-API-for-resource-backing-on-X.patch
+++ b/patches/0001-drm-virtio-use-the-DMA-API-for-resource-backing-on-X.patch
@@ -1,0 +1,124 @@
+From fe4973ef8a701733e42970a3be63c3335fd90cd0 Mon Sep 17 00:00:00 2001
+From: Ben Leggett <benjamin@edera.io>
+Date: Thu, 6 Aug 2026 15:51:03 -0400
+Subject: [PATCH] drm/virtio: use the DMA API for resource backing on Xen
+
+On a Xen PV domain page addressses bear no relation to the real machine
+addresses the host would have to use to reach it.
+virtio_ring.c handles this correctly, vring_use_dma_api()
+returns true for any xen_domain() regardless of VIRTIO_F_ACCESS_PLATFORM.
+virtio-gpu makes the same decision independently, but its copy
+looks only at the feature bit:
+
+	bool use_dma_api = !virtio_has_dma_quirk(vgdev->vdev);
+
+QEMU does not set iommu_platform on virtio-vga by default, so
+VIRTIO_F_ACCESS_PLATFORM is not negotiated, use_dma_api is false, and
+virtio_gpu_object_shmem_init() describes the framebuffer's backing pages
+to the host with sg_phys().  Those are guest-physical addresses.  In a PV
+domain they resolve, on the host side, to pages belonging to some other
+domain, so the host scans out unrelated memory.
+
+Fix is to move the decision into virtio_gpu_use_dma_api() and give it the
+xen_domain() check, like vring_use_dma_api() has. It
+additionally enables the dma_sync_sgtable_for_device() calls in
+virtgpu_vq.c, which are required for correctness whenever swiotlb
+is in play.
+
+Reproduced with a Xen 4.21 PV dom0 nested inside QEMU 8.2 with
+virtio-vga, on both a distro 6.8 kernel and 6.18 LTS. A PVH dom0 
+works fine and doesn't need this fix because it is identity-mapped,
+only PV dom0s are affected.
+
+Signed-off-by: Ben Leggett <benjamin@edera.io>
+---
+ drivers/gpu/drm/virtio/virtgpu_drv.h    | 24 ++++++++++++++++++++++++
+ drivers/gpu/drm/virtio/virtgpu_object.c |  2 +-
+ drivers/gpu/drm/virtio/virtgpu_vq.c     |  6 +++---
+ 3 files changed, 28 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/virtio/virtgpu_drv.h b/drivers/gpu/drm/virtio/virtgpu_drv.h
+index 2f35319..d41367e 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_drv.h
++++ b/drivers/gpu/drm/virtio/virtgpu_drv.h
+@@ -43,6 +43,8 @@
+ #include <drm/drm_probe_helper.h>
+ #include <drm/virtgpu_drm.h>
+ 
++#include <xen/xen.h>
++
+ #define DRIVER_NAME "virtio_gpu"
+ #define DRIVER_DESC "virtio GPU"
+ 
+@@ -60,6 +62,24 @@
+ /* See virtio_gpu_ctx_create. One additional character for NULL terminator. */
+ #define DEBUG_NAME_MAX_LEN 65
+ 
++/*
++ * Whether the host must be told about resource backing pages by DMA address
++ * rather than guest-physical address.
++ *
++ * This mirrors vring_use_dma_api() in drivers/virtio/virtio_ring.c, including
++ * its xen_domain() case.
++ */
++static inline bool virtio_gpu_use_dma_api(const struct virtio_device *vdev)
++{
++	if (!virtio_has_dma_quirk(vdev))
++		return true;
++
++	if (xen_domain())
++		return true;
++
++	return false;
++}
++
+ struct virtio_gpu_object_params {
+ 	unsigned long size;
+ 	bool dumb;
+diff --git a/drivers/gpu/drm/virtio/virtgpu_object.c b/drivers/gpu/drm/virtio/virtgpu_object.c
+index e6363c8..d228b5b 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_object.c
++++ b/drivers/gpu/drm/virtio/virtgpu_object.c
+@@ -161,7 +161,7 @@ static int virtio_gpu_object_shmem_init(struct virtio_gpu_device *vgdev,
+ 					struct virtio_gpu_mem_entry **ents,
+ 					unsigned int *nents)
+ {
+-	bool use_dma_api = !virtio_has_dma_quirk(vgdev->vdev);
++	bool use_dma_api = virtio_gpu_use_dma_api(vgdev->vdev);
+ 	struct scatterlist *sg;
+ 	struct sg_table *pages;
+ 	int si;
+diff --git a/drivers/gpu/drm/virtio/virtgpu_vq.c b/drivers/gpu/drm/virtio/virtgpu_vq.c
+index 83d46a8..4a72c69 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_vq.c
++++ b/drivers/gpu/drm/virtio/virtgpu_vq.c
+@@ -723,7 +723,7 @@ int virtio_gpu_panic_cmd_transfer_to_host_2d(struct virtio_gpu_device *vgdev,
+ 	struct virtio_gpu_object *bo = gem_to_virtio_gpu_obj(objs->objs[0]);
+ 	struct virtio_gpu_transfer_to_host_2d *cmd_p;
+ 	struct virtio_gpu_vbuffer *vbuf;
+-	bool use_dma_api = !virtio_has_dma_quirk(vgdev->vdev);
++	bool use_dma_api = virtio_gpu_use_dma_api(vgdev->vdev);
+ 
+ 	if (virtio_gpu_is_shmem(bo) && use_dma_api)
+ 		dma_sync_sgtable_for_device(vgdev->vdev->dev.parent,
+@@ -754,7 +754,7 @@ void virtio_gpu_cmd_transfer_to_host_2d(struct virtio_gpu_device *vgdev,
+ 	struct virtio_gpu_object *bo = gem_to_virtio_gpu_obj(objs->objs[0]);
+ 	struct virtio_gpu_transfer_to_host_2d *cmd_p;
+ 	struct virtio_gpu_vbuffer *vbuf;
+-	bool use_dma_api = !virtio_has_dma_quirk(vgdev->vdev);
++	bool use_dma_api = virtio_gpu_use_dma_api(vgdev->vdev);
+ 
+ 	if (virtio_gpu_is_shmem(bo) && use_dma_api)
+ 		dma_sync_sgtable_for_device(vgdev->vdev->dev.parent,
+@@ -1190,7 +1190,7 @@ void virtio_gpu_cmd_transfer_to_host_3d(struct virtio_gpu_device *vgdev,
+ 	struct virtio_gpu_object *bo = gem_to_virtio_gpu_obj(objs->objs[0]);
+ 	struct virtio_gpu_transfer_host_3d *cmd_p;
+ 	struct virtio_gpu_vbuffer *vbuf;
+-	bool use_dma_api = !virtio_has_dma_quirk(vgdev->vdev);
++	bool use_dma_api = virtio_gpu_use_dma_api(vgdev->vdev);
+ 
+ 	if (virtio_gpu_is_shmem(bo) && use_dma_api)
+ 		dma_sync_sgtable_for_device(vgdev->vdev->dev.parent,
+-- 
+2.55.0
+


### PR DESCRIPTION
This fixes noVNC et al showing garbage after booting into a PV dom0 under Xen.

Tested and confirmed with a locally built host kernel with this patch applied:

<img width="2177" height="1236" alt="image" src="https://github.com/user-attachments/assets/630f6652-a43d-4dfc-b559-f97306069b11" />
